### PR TITLE
working in unity 5.3.2f1

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ A utility to export static [Unity3d](http://unity3d.com/) scenes to [Three.js](h
 
 ### Usage
 
-Drop the contents of the `unity/Editor` folder in your Unity project `Assets` folder. A new option should appear in the top menu caled J3D. 
+Drop the contents of the `unity/Editor` folder in your Unity project `Assets` folder. A new option should appear in the top menu caled J3D.
 
-When you have your scene ready, select all objects (or those you want to export) and select J3D > Export. A dialog will appear with some settings (docs for this coming soon). 
+When you have your scene ready, select all objects (or those you want to export) and select J3D > Export. A dialog will appear with some settings (docs for this coming soon).
 
 When you hit Export, it will create two files:
 
@@ -37,7 +37,7 @@ Currently the exporter makes all names lowercase (ex. `RedCube` becomes `redcube
 
 ### What version of Unity and Three has this been tested on?
 
-- Unity 4.5.3f3 (it works with the free version)
+- Unity 5.3.2f1 (it works with the free version)
 - Three.js r68
 
 ### What it does export now?

--- a/html/J3DLoader.js
+++ b/html/J3DLoader.js
@@ -50,7 +50,7 @@ J3D.Loader.parseJSONScene = function(renderer, scene, jscene, jmeshes, jsanim) {
             g.vertices.push(new THREE.Vector3(vs[i], vs[i+1], vs[i+2]));
         }
 
-        var ns = jmeshes[mi].tris;
+        var ns = jmeshes[mi].indices;
         for(var i = 0, n = ns.length; i < n; i += 3) {
             g.faces.push(new THREE.Face3(ns[i], ns[i+2], ns[i+1]));
         }
@@ -70,7 +70,7 @@ J3D.Loader.parseJSONScene = function(renderer, scene, jscene, jmeshes, jsanim) {
     //         jsanim[i] = new J3D.Animation(jsanim[i]);
     //     }
     // }
-    
+
     // for (var txs in jscene.textures) {
     //     var tx = new J3D.Texture(jscene.path + jscene.textures[txs].file);
     //     jscene.textures[txs] = tx;
@@ -191,7 +191,7 @@ J3D.Loader.parseJSONScene = function(renderer, scene, jscene, jmeshes, jsanim) {
             t.scale.set(s[0], s[1], s[2]);
         }
 
-        if(td.mesh) t.geometry = jmeshes[td.mesh];
+        if(td.mesh) t.geometry = jmeshes[td.meshId];
         if(td.renderer) t.material = jscene.materials[td.renderer];
 
         // if (t.animation) t.animation = jsanim[t.animation];

--- a/unity/Assets/Editor/J3DExport.cs
+++ b/unity/Assets/Editor/J3DExport.cs
@@ -165,7 +165,7 @@ public class J3DExport : ScriptableWizard
 		if (t.GetComponent<Renderer>() != null) {
 			MeshExportData me = new MeshExportData (t);
 			if (!mex.ContainsKey (me.Name))
-				mex.Add (me.Id, me);
+				mex.Add (me.Name, me);
 			
 			List<string> textures = TextureUtil.ExtractTexturesNames (t.GetComponent<Renderer>().sharedMaterial);
 			

--- a/unity/Assets/Editor/data/AnimationExportData.cs
+++ b/unity/Assets/Editor/data/AnimationExportData.cs
@@ -95,7 +95,7 @@ public class AnimationExportData
 				( (AnimationProperty) properties["rz"] ).SamplesEx.Add ( r.z.ToString (ExporterProps.LN) );
 				*/
 			// }
-		}
+		//}
 	}
 	
 	public string Name {


### PR DESCRIPTION
with 5.3.2f1, current version is not working.
with this hotfix, It works on 5.3.21f.
## html/J3DLoader.js
- api changed
- etc
## unity/Assets/Editor/data/AnimationExportData.cs
- bracket mis-match
## unity/Assets/Editor/J3DExport.cs

contains / add -> key is not equal

```
if (!mex.ContainsKey (me.Name))
-  mex.Add (me.Id, me);
+  mex.Add (me.Name, me);
```
